### PR TITLE
Fix JWT 'jti' claim to be string for PyJWT 2.10+ compatibility

### DIFF
--- a/request_token/models.py
+++ b/request_token/models.py
@@ -169,7 +169,7 @@ class RequestToken(models.Model):
         return self.claims.get("iat")
 
     @property
-    def jti(self) -> int | None:
+    def jti(self) -> str | None:
         """Return the 'jti' claim, mapped to id."""
         return self.claims.get("jti")
 
@@ -192,7 +192,7 @@ class RequestToken(models.Model):
             "mod": self.login_mode[:1].lower(),
         }
         if self.id is not None:
-            claims["jti"] = self.id
+            claims["jti"] = str(self.id)
         if self.user is not None:
             claims["aud"] = str(self.user.pk)
         if self.expiration_time is not None:

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -116,7 +116,7 @@ class RequestTokenTests(TestCase):
         with mock.patch("request_token.models.tz_now", lambda: now):
             token.save()
             self.assertEqual(token.iat, now_sec)
-            self.assertEqual(token.jti, token.id)
+            self.assertEqual(token.jti, str(token.id))
             self.assertEqual(len(token.claims), 8)
 
     def test_json(self):


### PR DESCRIPTION
## Summary
- Fixes #65 by ensuring the JWT 'jti' claim is always a string
- Updates code to comply with JWT specification and PyJWT 2.10.0+ requirements
- All tests pass with the changes

## Background
PyJWT 2.10.0 introduced breaking changes that require the 'jti' (JWT ID) claim to be a string, as per the JWT RFC specification. Previously, non-string values were allowed but this is no longer the case.

## Changes
1. Convert the `jti` claim to string in `RequestToken.claims` property (models.py:195)
2. Update the `jti` property return type annotation from `int | None` to `str | None` (models.py:172)
3. Update test expectation to match string jti value (test_models.py:119)

## Test plan
- [x] Run existing test suite - all 76 tests pass
- [x] Verify code formatting with black
- [x] Run ruff linter checks
- [x] Manually tested that JWT encoding/decoding works correctly
- [x] Django's ORM handles the string-to-int conversion automatically when querying by ID